### PR TITLE
Parallel Hydro Erosion

### DIFF
--- a/Assets/Scenes/TerrainTestScene.unity
+++ b/Assets/Scenes/TerrainTestScene.unity
@@ -305,8 +305,8 @@ GameObject:
   - component: {fileID: 1427697598}
   - component: {fileID: 1427697600}
   - component: {fileID: 1427697599}
-  - component: {fileID: 1427697602}
   - component: {fileID: 1427697601}
+  - component: {fileID: 1427697602}
   m_Layer: 0
   m_Name: Terrain
   m_TagString: Untagged
@@ -376,8 +376,8 @@ MonoBehaviour:
   chunkSize: 16
   terrainShader: {fileID: 4800000, guid: d86c328af692b2e468a1111f86c00722, type: 3}
   terrainMaterial: {fileID: 2100000, guid: 9eef9a28c76784d4b8c9218515be9037, type: 2}
-  erodeInterval: 0.1
-  dropletsPerInterval: 100
+  erodeInterval: 1
+  dropletsPerInterval: 10000
   totalDroplets: 120000
   meshGenType: 0
 --- !u!114 &1427697602
@@ -389,22 +389,24 @@ MonoBehaviour:
   m_GameObject: {fileID: 1427697597}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5aa8d71520f88844680ae057321fbc39, type: 3}
+  m_Script: {fileID: 11500000, guid: f2e87c85f1249ce31819e63a39a09c03, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   seed: 0
-  inertia: 0.4
+  inertia: 0.05
   initialWater: 1
   initialVelocity: 1
-  gravity: 4
+  gravity: 9.81
   includeVelocity: 0
   sedimentCapacityFactor: 4
-  evaporationRate: 0.0125
+  evaporationRate: 0.0123
   minSlope: 0.01
   minCapacity: 0.1
   maxDropletLifetime: 32
-  depositionRate: 0.01
+  depositionRate: 0.1
   erosionRate: 0.1
-  erodeRadius: 6
+  erodeRadius: 3
   blurValue: 0
   blurRadius: 2
+  erosionType: 2
+  debugPerformance: 1

--- a/Assets/Scenes/TerrainTestScene.unity
+++ b/Assets/Scenes/TerrainTestScene.unity
@@ -376,8 +376,8 @@ MonoBehaviour:
   chunkSize: 16
   terrainShader: {fileID: 4800000, guid: d86c328af692b2e468a1111f86c00722, type: 3}
   terrainMaterial: {fileID: 2100000, guid: 9eef9a28c76784d4b8c9218515be9037, type: 2}
-  erodeInterval: 0.1
-  dropletsPerInterval: 1000
+  erodeInterval: 1
+  dropletsPerInterval: 10000
   totalDroplets: 120000
   meshGenType: 0
 --- !u!114 &1427697602

--- a/Assets/Scenes/TerrainTestScene.unity
+++ b/Assets/Scenes/TerrainTestScene.unity
@@ -376,8 +376,8 @@ MonoBehaviour:
   chunkSize: 16
   terrainShader: {fileID: 4800000, guid: d86c328af692b2e468a1111f86c00722, type: 3}
   terrainMaterial: {fileID: 2100000, guid: 9eef9a28c76784d4b8c9218515be9037, type: 2}
-  erodeInterval: 1
-  dropletsPerInterval: 10000
+  erodeInterval: 0.1
+  dropletsPerInterval: 1000
   totalDroplets: 120000
   meshGenType: 0
 --- !u!114 &1427697602
@@ -393,20 +393,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   seed: 0
-  inertia: 0.05
+  inertia: 0.4
   initialWater: 1
   initialVelocity: 1
-  gravity: 9.81
+  gravity: 4
   includeVelocity: 0
   sedimentCapacityFactor: 4
-  evaporationRate: 0.0123
+  evaporationRate: 0.0125
   minSlope: 0.01
   minCapacity: 0.1
   maxDropletLifetime: 32
-  depositionRate: 0.1
+  depositionRate: 0.01
   erosionRate: 0.1
-  erodeRadius: 3
+  erodeRadius: 4
   blurValue: 0
   blurRadius: 2
   erosionType: 2
-  debugPerformance: 1
+  debugPerformance: 0

--- a/Assets/Scenes/TerrainTestScene.unity
+++ b/Assets/Scenes/TerrainTestScene.unity
@@ -376,8 +376,8 @@ MonoBehaviour:
   chunkSize: 16
   terrainShader: {fileID: 4800000, guid: d86c328af692b2e468a1111f86c00722, type: 3}
   terrainMaterial: {fileID: 2100000, guid: 9eef9a28c76784d4b8c9218515be9037, type: 2}
-  erodeInterval: 1
-  dropletsPerInterval: 10000
+  erodeInterval: 0.1
+  dropletsPerInterval: 1000
   totalDroplets: 120000
   meshGenType: 0
 --- !u!114 &1427697602
@@ -400,8 +400,8 @@ MonoBehaviour:
   includeVelocity: 0
   sedimentCapacityFactor: 4
   evaporationRate: 0.0125
-  minSlope: 0.01
-  minCapacity: 0.1
+  minSlope: 0
+  minCapacity: 0
   maxDropletLifetime: 32
   depositionRate: 0.01
   erosionRate: 0.1

--- a/Assets/Scenes/TerrainTestScene.unity
+++ b/Assets/Scenes/TerrainTestScene.unity
@@ -377,7 +377,7 @@ MonoBehaviour:
   terrainShader: {fileID: 4800000, guid: d86c328af692b2e468a1111f86c00722, type: 3}
   terrainMaterial: {fileID: 2100000, guid: 9eef9a28c76784d4b8c9218515be9037, type: 2}
   erodeInterval: 0.1
-  dropletsPerInterval: 1000
+  dropletsPerInterval: 250
   totalDroplets: 120000
   meshGenType: 0
 --- !u!114 &1427697602
@@ -403,8 +403,8 @@ MonoBehaviour:
   minSlope: 0
   minCapacity: 0
   maxDropletLifetime: 32
-  depositionRate: 0.01
-  erosionRate: 0.1
+  depositionRate: 0.03
+  erosionRate: 0.3
   erodeRadius: 4
   blurValue: 0
   blurRadius: 2

--- a/Assets/Scripts/Terrain/Erosion/HydroErosionOperator.cs
+++ b/Assets/Scripts/Terrain/Erosion/HydroErosionOperator.cs
@@ -1,6 +1,5 @@
-using UnityEngine;
-using System;
 using Terrain.Map;
+using UnityEngine;
 
 namespace Terrain.Erosion {
     /// <summary>
@@ -22,7 +21,7 @@ namespace Terrain.Erosion {
     /// The raindrop will also slowly lose water and will die if it moves off the map
     /// or runs out of water completely. 
     /// </summary>
-    abstract public class AbstractHydroErosion : MonoBehaviour {
+    public class HydroErosionOperator : MonoBehaviour {
         /// <summary>
         /// Seed value for random number generator
         /// </summary>
@@ -144,9 +143,22 @@ namespace Terrain.Erosion {
         /// </summary>
         private HydroErosionParams erosionParams;
         /// <summary>
+        /// Type of erosion for construction the erosion module.
+        /// </summary>
+        public HydroErosionType erosionType;
+        /// <summary>
         /// Have erosion parameters been setup yet
         /// </summary>
         private bool setupParams;
+        /// <summary>
+        /// Module used to apply erosion to the terrain.
+        /// </summary>
+        private IHydroErosion erosion;
+
+        /// <summary>
+        /// Should performance be debugged to console
+        /// </summary>
+        public bool debugPerformance;
 
         /// <summary>
         /// Initializes the erosion parameters and prng
@@ -164,7 +176,9 @@ namespace Terrain.Erosion {
                     this.initialVelocity, this.gravity, this.includeVelocity,
                     this.sedimentCapacityFactor, this.evaporationRate, this.minSlope,
                     this.minCapacity, this.maxDropletLifetime, this.depositionRate,
-                    this.erosionRate, this.erodeRadius, this.blurValue, this.blurRadius);
+                    this.erosionRate, this.erodeRadius, this.blurValue, this.blurRadius,
+                    this.debugPerformance);
+                this.erosion = this.erosionType.ConstructErosion();
             }
         }
 
@@ -177,20 +191,7 @@ namespace Terrain.Erosion {
         /// <param name="iterations">Number of droplets to create</param>
         public void ErodeHeightMap(IHeightMap map, Vector2Int start, Vector2Int end, int iterations) {
             Initialize();
-            DoErosion(map, start, end, iterations, this.erosionParams, this.prng);
+            this.erosion.DoErosion(map, start, end, iterations, this.erosionParams, this.prng);
         }
-        
-        /// <summary>
-        /// Erodes a hight map by generating a set of droplets then simulating their movement along the height map.
-        /// </summary>
-        /// <param name="map">Map to apply changes to.</param>
-        /// <param name="start">Minimum location for spawning droplets (X,Y) position</param>
-        /// <param name="end">Maximum location for spawning droplets (X,Y) position</param>
-        /// <param name="iterations">Number of droplets to create</param>
-        /// <param name="erosionParams">Parameters for erosion</param>
-        /// <param name="prng">Random number generator for droplet spawning and decisions</param>
-        abstract protected void DoErosion(IHeightMap map, Vector2Int start, Vector2Int end, int iterations,
-            HydroErosionParams erosionParams, System.Random prng);
-
     }
 }

--- a/Assets/Scripts/Terrain/Erosion/HydroErosionOperator.cs.meta
+++ b/Assets/Scripts/Terrain/Erosion/HydroErosionOperator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2e87c85f1249ce31819e63a39a09c03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Erosion/HydroErosionParams.cs
+++ b/Assets/Scripts/Terrain/Erosion/HydroErosionParams.cs
@@ -23,12 +23,12 @@ namespace Terrain.Erosion {
         /// <param name="erodeRadius">Erosion radius of a droplet</param>
         /// <param name="blurValue">Amount of bluring for terrain after changes</param>
         /// <param name="blurRadius">Radius of blurring terrain after changes</param>
-        /// <param name="erodeBrush"></param>
-        /// <param name="blurBrush"></param>
+        /// <param name="debugPerformance">Should performance be debugged to console</param>
         public HydroErosionParams(float inertia, float initialWater, float initialVelocity, 
             float gravity, bool includeVelocity, float sedimentCapacityFactor, 
             float evaporationRate, float minSlope, float minCapacity, int maxDropletLifetime, float depositionRate,
-            float erodeRate, int erodeRadius, float blurValue, int blurRadius) {
+            float erodeRate, int erodeRadius, float blurValue, int blurRadius,
+            bool debugPerformance) {
             this.inertia = inertia;
             this.initialWater = initialWater;
             this.initialVelocity = initialVelocity;
@@ -46,6 +46,7 @@ namespace Terrain.Erosion {
             this.blurRadius = blurRadius;
             this.erodeBrush = InitGaussianBrush(erodeRadius, erodeRadius / 3.0f);
             this.blurBrush = InitGaussianBrush(blurRadius, blurRadius / 3.0f);
+            this.debugPerformance = debugPerformance;
         }
 
 
@@ -179,5 +180,10 @@ namespace Terrain.Erosion {
         /// Brush for blurring
         /// </summary>
         public readonly float[,] blurBrush;
+
+        /// <summary>
+        /// Print debug information about performance
+        /// </summary>
+        public readonly bool debugPerformance;
     }
 }

--- a/Assets/Scripts/Terrain/Erosion/HydroErosionType.cs
+++ b/Assets/Scripts/Terrain/Erosion/HydroErosionType.cs
@@ -6,6 +6,8 @@ namespace Terrain.Erosion {
     /// </summary>
     public enum HydroErosionType {
         Serial,
+        StateTransactionalMemory,
+        ParallelSpinLocks
     }
 
     /// <summary>
@@ -13,15 +15,19 @@ namespace Terrain.Erosion {
     /// </summary>
     static class HydroErosionTypeMethods {
         /// <summary>
-        /// Gets the type of component based on the HydroErosionType.
+        /// Gets a constructed hydro erosion based on the HydroErosionType.
         /// </summary>
-        /// <param name="meshGenType">HydroErosionType being returned.</param>
-        /// <returns>Some type that extends AbstractMeshGenerator</returns>
-        public static System.Type GetMeshGenType(this HydroErosionType meshGenType) {
-            switch (meshGenType) {
+        /// <param name="hydroErosionType">HydroErosionType being returned.</param>
+        /// <returns>An instance of the type of erosion being used.</returns>
+        public static IHydroErosion ConstructErosion(this HydroErosionType hydroErosionType) {
+            switch (hydroErosionType) {
+                case HydroErosionType.ParallelSpinLocks:
+                    return new PSLHydroErosion();
+                case HydroErosionType.StateTransactionalMemory:
+                    return new STMHydroErosion();
                 case HydroErosionType.Serial:
                 default:
-                    return typeof(SerialHydroErosion);
+                    return new SerialHydroErosion();
             }
         }
     }

--- a/Assets/Scripts/Terrain/Erosion/IHydroErosion.cs
+++ b/Assets/Scripts/Terrain/Erosion/IHydroErosion.cs
@@ -25,6 +25,8 @@ namespace Terrain.Erosion {
     public interface IHydroErosion {
         /// <summary>
         /// Erodes a hight map by generating a set of droplets then simulating their movement along the height map.
+        /// This will NOT change the height map. It only returns the set of changes that should 
+        /// be applied or blurred.
         /// </summary>
         /// <param name="map">Map to apply changes to.</param>
         /// <param name="start">Minimum location for spawning droplets (X,Y) position</param>
@@ -32,7 +34,8 @@ namespace Terrain.Erosion {
         /// <param name="iterations">Number of droplets to create</param>
         /// <param name="erosionParams">Parameters for erosion</param>
         /// <param name="prng">Random number generator for droplet spawning and decisions</param>
-        /// <returns>A change map of all the changes that need to be made to the TM</returns>
+        /// <returns>A change map of all the changes that need to be made to the map.
+        /// This change map should be applied to the original height map.</returns>
         IChangeMap DoErosion(IHeightMap map, Vector2Int start, Vector2Int end, int iterations,
             HydroErosionParams erosionParams, System.Random prng);
 

--- a/Assets/Scripts/Terrain/Erosion/IHydroErosion.cs
+++ b/Assets/Scripts/Terrain/Erosion/IHydroErosion.cs
@@ -32,7 +32,8 @@ namespace Terrain.Erosion {
         /// <param name="iterations">Number of droplets to create</param>
         /// <param name="erosionParams">Parameters for erosion</param>
         /// <param name="prng">Random number generator for droplet spawning and decisions</param>
-        void DoErosion(IHeightMap map, Vector2Int start, Vector2Int end, int iterations,
+        /// <returns>A change map of all the changes that need to be made to the TM</returns>
+        IChangeMap DoErosion(IHeightMap map, Vector2Int start, Vector2Int end, int iterations,
             HydroErosionParams erosionParams, System.Random prng);
 
     }

--- a/Assets/Scripts/Terrain/Erosion/IHydroErosion.cs
+++ b/Assets/Scripts/Terrain/Erosion/IHydroErosion.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using System;
+using Terrain.Map;
+
+namespace Terrain.Erosion {
+    /// <summary>
+    /// Simulated hydraulic erosion following 
+    /// Hans Theobald Beyer's "Implementation of a method for Hydraulic Erosion"
+    /// Bachelor's Thesis in Informatics at TECHNISCHE UNIVERSITÄT MÜNCHEN. 15.11.2015
+    /// 
+    /// https://www.firespark.de/resources/downloads/implementation%20of%20a%20methode%20for%20hydraulic%20erosion.pdf
+    /// 
+    /// Some of the documentation of parameters is directly from this document so if
+    /// there is any uncertainty there is further explanation in this paper.
+    /// 
+    /// Simulates Hydraulic erosion by spawning raindrops around the map. As the raindrops
+    /// move down the sides of the terrain they will erode sides of the mountian.
+    /// The raindrop's movement at each individual step will be one cell in the (x,y) direction.
+    /// If the raindrop is moving downhill quickly it will pick up sediment.
+    /// As the raindrop picks up sediment, it will fill up and slowly deposit sediment if it
+    /// becomes too full or slows down enough. 
+    /// The raindrop will also slowly lose water and will die if it moves off the map
+    /// or runs out of water completely. 
+    /// </summary>
+    public interface IHydroErosion {
+        /// <summary>
+        /// Erodes a hight map by generating a set of droplets then simulating their movement along the height map.
+        /// </summary>
+        /// <param name="map">Map to apply changes to.</param>
+        /// <param name="start">Minimum location for spawning droplets (X,Y) position</param>
+        /// <param name="end">Maximum location for spawning droplets (X,Y) position</param>
+        /// <param name="iterations">Number of droplets to create</param>
+        /// <param name="erosionParams">Parameters for erosion</param>
+        /// <param name="prng">Random number generator for droplet spawning and decisions</param>
+        void DoErosion(IHeightMap map, Vector2Int start, Vector2Int end, int iterations,
+            HydroErosionParams erosionParams, System.Random prng);
+
+    }
+}

--- a/Assets/Scripts/Terrain/Erosion/IHydroErosion.cs.meta
+++ b/Assets/Scripts/Terrain/Erosion/IHydroErosion.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f1b6a8465b4084c4b92a76661db3d220
+guid: 3119609cfb583da0bbe2c6eedda7dacc
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/Terrain/Erosion/PSLHydroErosion.cs
+++ b/Assets/Scripts/Terrain/Erosion/PSLHydroErosion.cs
@@ -1,34 +1,36 @@
-using UnityEngine;
-using Terrain.Map;
 using System;
+using System.Linq;
+using Terrain.Map;
+using UnityEngine;
 
 namespace Terrain.Erosion {
     /// <summary>
-    /// Performs Hydraulic Erosion in Serial, one droplet at a time
+    /// Performs Hydraulic Erosion in Parallel using Spin Locks,
+    /// as many droplets at a time as possible.
     /// <see cref="AbstractHydroErosion"/> for more details.
     /// </summary>
-    public class SerialHydroErosion : IHydroErosion {
-
+    public class PSLHydroErosion : IHydroErosion {
         /// <summary>
-        /// Does erosion in Serial
+        /// Does erosion in Parallel using Spin Locks
         /// <see cref="AbstractHydroErosion.DoErosion"/> for more information
         /// <seealso cref="AbstractHydroErosion"/>
         /// </summary>
         public void DoErosion(IHeightMap heightMap, Vector2Int start, Vector2Int end, int iterations,
-            HydroErosionParams erosionParams, System.Random prng)
-        {
+            HydroErosionParams erosionParams, System.Random prng) {
             // Map for changes in current set of raindrops
-            IChangeMap deltaMap = new ChangeMap(end.x - start.x, end.y - start.y);
+            IChangeMap deltaMap = new SpinLockChangeMap(end.x - start.x, end.y - start.y);
             // Layered map for storing information about the original map and delta map together
             LayeredMap layers = new LayeredMap(deltaMap, heightMap);
 
-            long startMillis = System.DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
-            // Iteration for each raindrop
-            for (int iter = 0; iter < iterations; iter++) {
+            Action<int> dropAction = i => {
                 Droplet droplet = Droplet.CreateRandomizedDroplet(prng, erosionParams, layers, 
                     start, end);
                 Droplet.SimulateDroplet(droplet);
-            }
+            };
+
+            long startMillis = System.DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+            // Iteration for each raindrop
+            ParallelEnumerable.Range(0, iterations).ForAll(dropAction);
 
             if (erosionParams.debugPerformance) {
                 float deltaMillis = System.DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond - startMillis;
@@ -54,4 +56,3 @@ namespace Terrain.Erosion {
         }
     }
 }
-

--- a/Assets/Scripts/Terrain/Erosion/PSLHydroErosion.cs
+++ b/Assets/Scripts/Terrain/Erosion/PSLHydroErosion.cs
@@ -15,7 +15,7 @@ namespace Terrain.Erosion {
         /// <see cref="AbstractHydroErosion.DoErosion"/> for more information
         /// <seealso cref="AbstractHydroErosion"/>
         /// </summary>
-        public void DoErosion(IHeightMap heightMap, Vector2Int start, Vector2Int end, int iterations,
+        public IChangeMap DoErosion(IHeightMap heightMap, Vector2Int start, Vector2Int end, int iterations,
             HydroErosionParams erosionParams, System.Random prng) {
             // Map for changes in current set of raindrops
             IChangeMap deltaMap = new SpinLockChangeMap(end.x - start.x, end.y - start.y);
@@ -36,23 +36,7 @@ namespace Terrain.Erosion {
                 float deltaMillis = System.DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond - startMillis;
                 Debug.Log("Total Millis: " + deltaMillis + ", Millis Per Droplet: " + deltaMillis / iterations);
             }
-
-            // If bluring changes, do steps to blur map
-            if (erosionParams.blurValue > 0) {
-                // Calculate the blurred map by applying the blur brush kernel to the map
-                IChangeMap blurredMap = deltaMap.ApplyKernel(erosionParams.blurBrush);
-                // Multiply the original map and blurred map by ratios
-                blurredMap.Multiply(erosionParams.blurValue);
-                deltaMap.Multiply(1 - erosionParams.blurValue);
-
-                // Apply changes to the original height map
-                blurredMap.ApplyChangesToMap(heightMap);
-                deltaMap.ApplyChangesToMap(heightMap);
-            }
-            // If not bluring changes, just ignore that complexity
-            else {
-                deltaMap.ApplyChangesToMap(heightMap);
-            }
+            return deltaMap;
         }
     }
 }

--- a/Assets/Scripts/Terrain/Erosion/PSLHydroErosion.cs.meta
+++ b/Assets/Scripts/Terrain/Erosion/PSLHydroErosion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 550c4251f45db2c299d7184f9647f92e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Erosion/STMHydroErosion.cs
+++ b/Assets/Scripts/Terrain/Erosion/STMHydroErosion.cs
@@ -1,34 +1,40 @@
-using UnityEngine;
-using Terrain.Map;
 using System;
+using System.Linq;
+using Shielded;
+using Terrain.Map;
+using UnityEngine;
 
 namespace Terrain.Erosion {
     /// <summary>
-    /// Performs Hydraulic Erosion in Serial, one droplet at a time
+    /// Performs Hydraulic Erosion in Parallel using State Transactional Memory,
+    /// as many droplets at a time as possible.
     /// <see cref="AbstractHydroErosion"/> for more details.
     /// </summary>
-    public class SerialHydroErosion : IHydroErosion {
-
+    public class STMHydroErosion : IHydroErosion {
         /// <summary>
-        /// Does erosion in Serial
+        /// Does erosion in Parallel Using State Transactional Memory
         /// <see cref="AbstractHydroErosion.DoErosion"/> for more information
         /// <seealso cref="AbstractHydroErosion"/>
         /// </summary>
         public void DoErosion(IHeightMap heightMap, Vector2Int start, Vector2Int end, int iterations,
-            HydroErosionParams erosionParams, System.Random prng)
-        {
+            HydroErosionParams erosionParams, System.Random prng) {
             // Map for changes in current set of raindrops
-            IChangeMap deltaMap = new ChangeMap(end.x - start.x, end.y - start.y);
+            IChangeMap deltaMap = new ShieldedChangeMap(end.x - start.x, end.y - start.y);
             // Layered map for storing information about the original map and delta map together
             LayeredMap layers = new LayeredMap(deltaMap, heightMap);
 
             long startMillis = System.DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
-            // Iteration for each raindrop
-            for (int iter = 0; iter < iterations; iter++) {
+
+            Action<int> raindrop = i => {
                 Droplet droplet = Droplet.CreateRandomizedDroplet(prng, erosionParams, layers, 
                     start, end);
-                Droplet.SimulateDroplet(droplet);
-            }
+                Shield.InTransaction(() => {
+                    Droplet.SimulateDroplet(droplet);
+                });
+            };
+
+            // Iteration for each raindrop
+            ParallelEnumerable.Range(0, iterations).ForAll(raindrop);
 
             if (erosionParams.debugPerformance) {
                 float deltaMillis = System.DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond - startMillis;
@@ -54,4 +60,3 @@ namespace Terrain.Erosion {
         }
     }
 }
-

--- a/Assets/Scripts/Terrain/Erosion/STMHydroErosion.cs
+++ b/Assets/Scripts/Terrain/Erosion/STMHydroErosion.cs
@@ -16,7 +16,7 @@ namespace Terrain.Erosion {
         /// <see cref="AbstractHydroErosion.DoErosion"/> for more information
         /// <seealso cref="AbstractHydroErosion"/>
         /// </summary>
-        public void DoErosion(IHeightMap heightMap, Vector2Int start, Vector2Int end, int iterations,
+        public IChangeMap DoErosion(IHeightMap heightMap, Vector2Int start, Vector2Int end, int iterations,
             HydroErosionParams erosionParams, System.Random prng) {
             // Map for changes in current set of raindrops
             IChangeMap deltaMap = new ShieldedChangeMap(end.x - start.x, end.y - start.y);
@@ -41,22 +41,7 @@ namespace Terrain.Erosion {
                 Debug.Log("Total Millis: " + deltaMillis + ", Millis Per Droplet: " + deltaMillis / iterations);
             }
 
-            // If bluring changes, do steps to blur map
-            if (erosionParams.blurValue > 0) {
-                // Calculate the blurred map by applying the blur brush kernel to the map
-                IChangeMap blurredMap = deltaMap.ApplyKernel(erosionParams.blurBrush);
-                // Multiply the original map and blurred map by ratios
-                blurredMap.Multiply(erosionParams.blurValue);
-                deltaMap.Multiply(1 - erosionParams.blurValue);
-
-                // Apply changes to the original height map
-                blurredMap.ApplyChangesToMap(heightMap);
-                deltaMap.ApplyChangesToMap(heightMap);
-            }
-            // If not bluring changes, just ignore that complexity
-            else {
-                deltaMap.ApplyChangesToMap(heightMap);
-            }
+            return deltaMap;
         }
     }
 }

--- a/Assets/Scripts/Terrain/Erosion/STMHydroErosion.cs.meta
+++ b/Assets/Scripts/Terrain/Erosion/STMHydroErosion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61ca7cf959a054ed58732802302e35d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Erosion/SerialHydroErosion.cs
+++ b/Assets/Scripts/Terrain/Erosion/SerialHydroErosion.cs
@@ -14,7 +14,7 @@ namespace Terrain.Erosion {
         /// <see cref="AbstractHydroErosion.DoErosion"/> for more information
         /// <seealso cref="AbstractHydroErosion"/>
         /// </summary>
-        public void DoErosion(IHeightMap heightMap, Vector2Int start, Vector2Int end, int iterations,
+        public IChangeMap DoErosion(IHeightMap heightMap, Vector2Int start, Vector2Int end, int iterations,
             HydroErosionParams erosionParams, System.Random prng)
         {
             // Map for changes in current set of raindrops
@@ -34,23 +34,7 @@ namespace Terrain.Erosion {
                 float deltaMillis = System.DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond - startMillis;
                 Debug.Log("Total Millis: " + deltaMillis + ", Millis Per Droplet: " + deltaMillis / iterations);
             }
-
-            // If bluring changes, do steps to blur map
-            if (erosionParams.blurValue > 0) {
-                // Calculate the blurred map by applying the blur brush kernel to the map
-                IChangeMap blurredMap = deltaMap.ApplyKernel(erosionParams.blurBrush);
-                // Multiply the original map and blurred map by ratios
-                blurredMap.Multiply(erosionParams.blurValue);
-                deltaMap.Multiply(1 - erosionParams.blurValue);
-
-                // Apply changes to the original height map
-                blurredMap.ApplyChangesToMap(heightMap);
-                deltaMap.ApplyChangesToMap(heightMap);
-            }
-            // If not bluring changes, just ignore that complexity
-            else {
-                deltaMap.ApplyChangesToMap(heightMap);
-            }
+            return deltaMap;
         }
     }
 }

--- a/Assets/Scripts/Terrain/Map/IChangeMap.cs
+++ b/Assets/Scripts/Terrain/Map/IChangeMap.cs
@@ -1,0 +1,67 @@
+namespace Terrain.Map {
+    /// <summary>
+    /// Change map, this is a performance map that starts
+    /// with all values initialized to zero and should contain a 
+    /// small delta to adjust a more persistent height map.
+    /// </summary>
+    public interface IChangeMap : IHeightMap {
+
+        /// <summary>
+        /// Adds all the changes stored in this map to another map (does a sum on the other map)
+        /// </summary>
+        /// <param name="targetMap"> Map to add changes to. </param>
+        void ApplyChangesToMap(IHeightMap targetMap);
+
+        /// <summary>
+        /// Multiply all values in this map by a scalar. This changes this map.
+        /// </summary>
+        /// <param name="scalar">Scalar value to multiply and change all values in the map by.</param>
+        void Multiply(float scalar);
+
+        /// <summary>
+        /// Gets a duplicate ChangeMap with the kernel applied to every element in the matrix.
+        /// </summary>
+        /// <param name="kernel">Kernel</param>
+        /// <returns>Duplicate map with kernel applied to every cell</returns>
+        IChangeMap ApplyKernel(float[,] kernel);
+    }
+
+    /// <summary>
+    /// Static functions for any IChangeMap that are useful for any function.
+    /// </summary>
+    public static class IChangeMapExtensions {
+        /// <summary>
+        /// Run a kernel to a individual pixel. Returns the sum of the kernel applied to that pixel.
+        /// Does NOT change the map.
+        /// </summary>
+        /// <param name="x">X position in grid (Center of kernel)</param>
+        /// <param name="y">Y position in grid (Center of kernel)</param>
+        /// <param name="kernel">Kernel to get summed value of</param>
+        /// <returns>The sum of the weighted values around the center x and y. If a 
+        /// value is not inside the grid, it is excluded for the weights and the other elements are weighted
+        /// proportionally more.</returns>
+        public static float Kernel(this IChangeMap map, int x, int y, float[,] kernel) {
+            float totalWeights = 0;
+            int width = kernel.GetLength(0);
+            int height = kernel.GetLength(1);
+            for (int kx = 0; kx < width; kx++) {
+                for (int ky = 0; ky < height; ky++) {
+                    if (map.IsInBounds(x + kx - width / 2, y + ky - height / 2)) {
+                        totalWeights += kernel[kx, ky];
+                    }
+                }
+            }
+
+            float wSum = 0;
+            for (int kx = 0; kx < width; kx++) {
+                for (int ky = 0; ky < height; ky++) {
+                    if (map.IsInBounds(x + kx - width / 2, y + ky - height / 2)) {
+                        wSum += kernel[kx, ky] / totalWeights *
+                                map.GetHeight(x - kx + width / 2, y + ky - height / 2);
+                    }
+                }
+            }
+            return wSum;
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/Map/IChangeMap.cs.meta
+++ b/Assets/Scripts/Terrain/Map/IChangeMap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af90d6287a27106f29059756c11c6a78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Map/ShieldedChangeMap.cs
+++ b/Assets/Scripts/Terrain/Map/ShieldedChangeMap.cs
@@ -69,6 +69,13 @@ namespace Terrain.Map {
         }
 
         /// <summary>
+        /// Clears this map of all changes
+        /// </summary>
+        public void Clear() {
+            this.map.Clear();
+        }
+
+        /// <summary>
         /// Checks if a coordinate is in the bounds of the heightmap.
         /// </summary>
         /// <param name="x">X position in the height map</param>

--- a/Assets/Scripts/Terrain/Map/ShieldedChangeMap.cs.meta
+++ b/Assets/Scripts/Terrain/Map/ShieldedChangeMap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dfa3f1bcb82fa5bb978617196a48c47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Map/SpinLockChangeMap.cs
+++ b/Assets/Scripts/Terrain/Map/SpinLockChangeMap.cs
@@ -138,7 +138,7 @@ namespace Terrain.Map {
         /// <param name="kernel">Kernel</param>
         /// <returns>Duplicate map with kernel applied to every cell</returns>
         public IChangeMap ApplyKernel(float[,] kernel) {
-            ChangeMap applied = new ChangeMap(this.dimX, this.dimY);
+            SpinLockChangeMap applied = new SpinLockChangeMap(this.dimX, this.dimY);
 
             ParallelEnumerable.Range(0, this.dimX * this.dimY).ForAll(
                 i => {

--- a/Assets/Scripts/Terrain/Map/SpinLockChangeMap.cs.meta
+++ b/Assets/Scripts/Terrain/Map/SpinLockChangeMap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 701684c951f7d03d895a6a2e828c253a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/MeshGen/LargeMapChunkLoader.cs
+++ b/Assets/Scripts/Terrain/MeshGen/LargeMapChunkLoader.cs
@@ -7,7 +7,7 @@ namespace Terrain.MeshGen {
     /// Loads a map from a LargeHeightMap into the world.
     /// </summary>
     [RequireComponent(typeof(LargeHeightMap))]
-    [RequireComponent(typeof(AbstractHydroErosion))]
+    [RequireComponent(typeof(HydroErosionOperator))]
     public class LargeMapChunkLoader : MonoBehaviour {
         
         /// <summary>
@@ -79,7 +79,7 @@ namespace Terrain.MeshGen {
                 if (this.elapsed > this.erodeInterval) {
                     this.elapsed %= this.erodeInterval;
 
-                    AbstractHydroErosion erosion = GetComponent<AbstractHydroErosion>();
+                    HydroErosionOperator erosion = GetComponent<HydroErosionOperator>();
                     erosion.ErodeHeightMap(this.heightMap, 
                         new Vector2Int(0, 0), new Vector2Int(this.heightMap.mapSize, this.heightMap.mapSize),
                         this.dropletsPerInterval);

--- a/Images/ErosionPanel.png
+++ b/Images/ErosionPanel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71b5c56c96e485fcea2ad51e184d32e3f2f9e32f6752a3273712bde940cc4965
+size 40866


### PR DESCRIPTION
# Description

Added options for various multi threaded parallel erosion. Also upgraded erosion panel to be more
generic and operate using a drop down menu.

New panel for operating erosion
![Panel with various options for erosion and highlighted selector widget](https://media.githubusercontent.com/media/nicholas-maltbie/ParallelEnvironment/STMHydroErosion/Images/ErosionPanel.png)

Types of erosion added
* Serial - Current method, does one droplet at a time.
* State Transaction Memory - Using shielded Library. Treats change map like clojure
* Parallel With Spin Locks - Runs in parallel using spin locks to avoid conflicts when
making changes to the map.

In addition to these changes, the ChangeMap has also be changed to have an
additional generic interface IChangeMap with two new extensions, SpinLockChangeMap,
and SheildedChangeMap. ShieldedChangeMap uses the Shielded api and an array of Shielded floats to update the state. The SpinLockChangeMap uses spin locks to manage conflicts between droplets.

# How Has This Been Tested?

This panel has been added to the Terrain Test Scene and the panel has been added 
the the `Terrain` object in the global hierarchy. You can select option for the panel 
then run the scene.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] New and existing unit tests pass locally with my changes~~

(No testing framework setup yet so ignore the last two)
